### PR TITLE
Add client only install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Works on RedHat-based and Debian-based Linux versions.
 Install the following software:
  - ansible (2.4.0 or higher)
  - git
- 
-Note: sometimes the Ansible scripts exit with a segmentation fault; this can be ignored.
+
+Note: sometimes the Ansible scripts exit with a segmentation fault - this can be ignored.
 
 ## Installing the GUI only
 This is for setting up a NICOS client machine.
@@ -22,18 +22,6 @@ ansible-playbook install-nicos-client.yml
 ## Installing the server
 This is for setting up a NICOS server machine (i.e. an instrument machine).
 
-All the useful variables are defined in the playbook `install-nicos.yml`.
-
-### Setting the facility and instrument
-By default the ansible script will set NICOS to use the demo instrument. This can be changed by editing the `install-nicos.yml` file to set a facility and instrument, for example:
-```
-...
-nicos_facility: "nicos_ess"
-nicos_instrument: "essiip"
-...
-```
-These settings can be changed post-installation by editing the `nicos.conf` file in `/opt/nicos`.
-
 ### Installing locally
 The anisble script will install on localhost by default.
 
@@ -42,6 +30,19 @@ To install run:
 ```shell
 sudo ansible-playbook install-nicos.yml
 ```
+
+By default the ansible script will set NICOS to use the demo instrument. This can be changed by supplying additional command line arguments, for example:
+
+```shell
+sudo ansible-playbook install-nicos.yml -e facility=ess -e instrument=essiip
+```
+or:
+
+```shell
+sudo ansible-playbook install-nicos.yml -e facility=ess -e instrument=v20
+```
+
+These settings can be changed post-installation by editing the `nicos.conf` file in `/opt/nicos`.
 
 ### Installing NICOS on a different machine (not localhost)
 Make sure that the ``hosts`` file points to the IP of the machine where NICOS is to be installed.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Works on RedHat-based and Debian-based Linux versions.
 Install the following software:
  - ansible (2.4.0 or higher)
  - git
+ 
+Note: sometimes the Ansible scripts exit with a segmentation fault; this can be ignored.
 
 ## Installing the GUI only
 This is for setting up a NICOS client machine.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
 # ansible-nicos
-Ansible installer for NICOS. Can also start and stop the NICOS services.
+Ansible installer for NICOS.
 
 ## Prerequisites
-Works on RedHat and Debian based Linux.
+Works on RedHat-based and Debian-based Linux versions.
 
 Install the following software:
  - ansible (2.4.0 or higher)
  - git
- 
-## Setting the facility and instrument
+
+## Installing the GUI only
+This is for setting up a NICOS client machine.
+
+To install the NICOS GUI on the local machine run:
+
+```shell
+ansible-playbook install-nicos-client.yml
+```
+
+## Installing the server
+This is for setting up a NICOS server machine (i.e. an instrument machine).
+
+All the useful variables are defined in the playbook `install-nicos.yml`.
+
+### Setting the facility and instrument
 By default the ansible script will set NICOS to use the demo instrument. This can be changed by editing the `install-nicos.yml` file to set a facility and instrument, for example:
 ```
 ...
@@ -18,22 +32,24 @@ nicos_instrument: "essiip"
 ```
 These settings can be changed post-installation by editing the `nicos.conf` file in `/opt/nicos`.
 
-## Installing NICOS on a different machine (not localhost)
-Make sure that the ``hosts`` file points to the IP of the machine where NICOS is to be installed.
+### Installing locally
+The anisble script will install on localhost by default.
 
-The playbook ``install-nicos.yml`` sets up everything including:
- - installing NICOS
- - installing the requirements
- - creating data directories
- - setting up NICOS instruments
- - creating the service files.
-
-All the useful variables are defined in the playbook.
+To install run:
 
 ```shell
-ansible-playbook -i hosts install-nicos.yml
+sudo ansible-playbook install-nicos.yml
 ```
 
+### Installing NICOS on a different machine (not localhost)
+Make sure that the ``hosts`` file points to the IP of the machine where NICOS is to be installed.
+
+To install on that machine:
+```shell
+ansible-playbook -i hosts install-nicos.yml -e host=NICOS
+```
+
+### Trouble-shooting
 If the playbook fails with the message:
 
 ```
@@ -41,15 +57,7 @@ If the playbook fails with the message:
 ```
 add ``-c paramiko`` to the previous command.
 
-### Installing locally
-Edit the `install-nicos.yml` file so that the `hosts` setting is `localhost`.
-Then run using:
-
-```shell
-sudo ansible-playbook install-nicos.yml
-```
-
-## Start and stop NICOS services
+## Start and stop NICOS services (server only)
 
 The playbooks ``start_nicos_services.yml``, ``stop_nicos_services.yml`` and ``restart_nicos_services.yml`` can be used to start, stop and restart the NICOS services.
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,0 +1,10 @@
+    http_proxy: ""
+    nicos_repo: "https://forge.frm2.tum.de/review/frm2/nicos/nicos-core"
+    nicos_version: "HEAD"
+    nicos_refspec: "HEAD"
+    nicos_src_dir: "/opt/nicos-core"
+    nicos_inst_dir: "/opt/nicos"
+    nicos_data_dir: "/opt/nicos-data"
+    nicos_facility: "{{ facility | default('demo') }}"
+    nicos_instrument: "{{ instrument | default('demo') }}"
+    

--- a/install-nicos-client.yml
+++ b/install-nicos-client.yml
@@ -1,14 +1,6 @@
 ---
 
 - hosts: "{{ host | default('localhost') }}"
-  vars:
-    http_proxy: ""
-    nicos_repo: "https://forge.frm2.tum.de/review/frm2/nicos/nicos-core"
-    nicos_version: "HEAD"
-    nicos_refspec: "HEAD"
-    nicos_src_dir: "/opt/nicos-core"
-    nicos_facility: "{{ facility | default('nicos_demo') }}"
-    nicos_instrument: "{{ instrument | default('demo') }}"
 
   tasks:
     - include: "tasks/download-nicos.yml"

--- a/install-nicos-client.yml
+++ b/install-nicos-client.yml
@@ -1,19 +1,17 @@
 ---
 
-- hosts: "{{ variable_host | default('localhost') }}"
+- hosts: "{{ host | default('localhost') }}"
   vars:
     http_proxy: ""
     nicos_repo: "https://forge.frm2.tum.de/review/frm2/nicos/nicos-core"
     nicos_version: "HEAD"
     nicos_refspec: "HEAD"
     nicos_src_dir: "/opt/nicos-core"
-    nicos_inst_dir: "/opt/nicos"
-    nicos_data_dir: "/opt/nicos-data"
-    nicos_facility: "nicos_demo"
-    nicos_instrument: "demo"
+    nicos_facility: "{{ facility | default('nicos_demo') }}"
+    nicos_instrument: "{{ instrument | default('demo') }}"
 
   tasks:
-    - include: "tasks/download-nicos.yml"  
+    - include: "tasks/download-nicos.yml"
 
     - include: "tasks/{{ ansible_os_family }}-packages.yml"
 
@@ -26,4 +24,3 @@
         dest: /usr/local/bin/nicos-gui
         state: link
         force: yes
-

--- a/install-nicos-client.yml
+++ b/install-nicos-client.yml
@@ -1,0 +1,29 @@
+---
+
+- hosts: "{{ variable_host | default('localhost') }}"
+  vars:
+    http_proxy: ""
+    nicos_repo: "https://forge.frm2.tum.de/review/frm2/nicos/nicos-core"
+    nicos_version: "HEAD"
+    nicos_refspec: "HEAD"
+    nicos_src_dir: "/opt/nicos-core"
+    nicos_inst_dir: "/opt/nicos"
+    nicos_data_dir: "/opt/nicos-data"
+    nicos_facility: "nicos_demo"
+    nicos_instrument: "demo"
+
+  tasks:
+    - include: "tasks/download-nicos.yml"  
+
+    - include: "tasks/{{ ansible_os_family }}-packages.yml"
+
+    - include: "tasks/install-python-packages.yml"
+
+    - name: create a link for nicos-gui
+      become: yes
+      file:
+        src: "{{ nicos_src_dir }}/bin/nicos-gui"
+        dest: /usr/local/bin/nicos-gui
+        state: link
+        force: yes
+

--- a/install-nicos.yml
+++ b/install-nicos.yml
@@ -1,16 +1,6 @@
 ---
 
 - hosts: "{{ variable_host | default('localhost') }}"
-  vars:
-    http_proxy: ""
-    nicos_repo: "https://forge.frm2.tum.de/review/frm2/nicos/nicos-core"
-    nicos_version: "HEAD"
-    nicos_refspec: "HEAD"
-    nicos_src_dir: "/opt/nicos-core"
-    nicos_inst_dir: "/opt/nicos"
-    nicos_data_dir: "/opt/nicos-data"
-    nicos_facility: "{{ facility | default('demo') }}"
-    nicos_instrument: "{{ instrument | default('demo') }}"
 
   tasks:
     - include: "tasks/download-nicos.yml"

--- a/install-nicos.yml
+++ b/install-nicos.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: nicos
+- hosts: "{{ variable_host | default('localhost') }}"
   vars:
     http_proxy: ""
     nicos_repo: "https://forge.frm2.tum.de/review/frm2/nicos/nicos-core"
@@ -13,20 +13,7 @@
     nicos_instrument: "demo"
 
   tasks:
-    - name: cleanup the current src dir
-      become: yes
-      file:
-        path: '{{nicos_src_dir}}'
-        state: absent
-
-    - name: make sure nicos is checked out
-      become: yes
-      git:
-        repo: '{{ nicos_repo }}'
-        dest: '{{ nicos_src_dir }}'
-        version: '{{ nicos_version }}'
-        refspec: '{{ nicos_refspec }}'
-        force: yes
+    - include: "tasks/download-nicos.yml"    
 
     - include: "tasks/{{ ansible_os_family }}-packages.yml"
 

--- a/install-nicos.yml
+++ b/install-nicos.yml
@@ -9,11 +9,11 @@
     nicos_src_dir: "/opt/nicos-core"
     nicos_inst_dir: "/opt/nicos"
     nicos_data_dir: "/opt/nicos-data"
-    nicos_facility: "nicos_demo"
-    nicos_instrument: "demo"
+    nicos_facility: "{{ facility | default('demo') }}"
+    nicos_instrument: "{{ instrument | default('demo') }}"
 
   tasks:
-    - include: "tasks/download-nicos.yml"    
+    - include: "tasks/download-nicos.yml"
 
     - include: "tasks/{{ ansible_os_family }}-packages.yml"
 

--- a/tasks/download-nicos.yml
+++ b/tasks/download-nicos.yml
@@ -1,0 +1,16 @@
+---
+
+- name: cleanup the current src dir
+  become: yes
+  file:
+    path: '{{nicos_src_dir}}'
+    state: absent
+
+- name: make sure nicos is checked out
+  become: yes
+  git:
+    repo: '{{ nicos_repo }}'
+    dest: '{{ nicos_src_dir }}'
+    version: '{{ nicos_version }}'
+    refspec: '{{ nicos_refspec }}'
+    force: yes

--- a/tasks/install-python-packages.yml
+++ b/tasks/install-python-packages.yml
@@ -19,10 +19,3 @@
     state: latest
     requirements: '{{ nicos_src_dir }}/requirements.txt'
     extra_args: "--proxy={{ http_proxy }} --ignore-installed"
-
-- name: install python dev requirements
-  become: yes
-  pip:
-    state: latest
-    requirements: '{{ nicos_src_dir }}/requirements-dev.txt'
-    extra_args: "--proxy={{ http_proxy }} --ignore-installed"

--- a/templates/nicos.conf.j2
+++ b/templates/nicos.conf.j2
@@ -4,8 +4,8 @@ group=nicos
 services=cache,poller,daemon
 pid_path={{nicos_data_dir}}/pid
 logging_path={{nicos_data_dir}}/log
-setup_package={{nicos_facility}}
+setup_package=nicos_{{nicos_facility}}
 instrument={{nicos_instrument}}
 
 [environment]
-INSTRUMENT={{nicos_facility}}.{{nicos_instrument}}
+INSTRUMENT=nicos_{{nicos_facility}}.{{nicos_instrument}}


### PR DESCRIPTION
This adds a script for doing client-only installations.
It also adds more instructions and by default installs to localhost.

In the future, I would like to be able to specify the facility and instrument as a command line option.