### PR TITLE
Add download nicos option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,39 @@ To install run:
 sudo ansible-playbook install-nicos.yml
 ```
 
-By default the ansible script will set NICOS to use the demo instrument. This can be changed by supplying additional command line arguments, for example:
+By default the ansible script will set NICOS to use the demo instrument.
+This and other install details can be changed by supplying additional command line arguments:
 
 ```shell
-sudo ansible-playbook install-nicos.yml -e facility=ess -e instrument=essiip -e username=nicosuser -e usergroup=nicosuser
+facilty - specify the overall facility (e.g. ess, sinq, demo etc.)
+instrument - specify the instrument at the nicos_facility (e.g. amor, cspec etc.)
+username - the UN*X user to install nicos as
+usergroup - the UN*X group to install nicos as
+host - the machine to install on (default is localhost)
+download - 'yes' will download NICOS from the ESS staging area rather than cloning it from Gerrit
 ```
-or:
+
+#### Examples
+
+Install as a specific instrument:
 
 ```shell
 sudo ansible-playbook install-nicos.yml -e facility=ess -e instrument=v20
 ```
 
-These settings can be changed post-installation by editing the `nicos.conf` file in `/opt/nicos`.
+Install as a specific instrument and user:
+
+```shell
+sudo ansible-playbook install-nicos.yml -e facility=ess -e instrument=essiip -e username=nicos_user -e usergroup=nicos_user
+```
+
+Note: facility and instrument settings can be changed post-installation by editing the `nicos.conf` file in `/opt/nicos`.
+
+Install from the ESS staging area:
+
+```shell
+sudo ansible-playbook install-nicos.yml -e facility=ess -e instrument=essiip -e download=yes
+```
 
 ### Installing NICOS on a different machine (not localhost)
 Make sure that the ``hosts`` file points to the IP of the machine where NICOS is to be installed.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ This and other install details can be changed by supplying additional command li
 ```shell
 facilty - specify the overall facility (e.g. ess, sinq, demo etc.)
 instrument - specify the instrument at the nicos_facility (e.g. amor, cspec etc.)
-username - the UN*X user to install nicos as
-usergroup - the UN*X group to install nicos as
-host - the machine to install on (default is localhost)
+username - the un*x user to install nicos as
+usergroup - the un*x group to install nicos as
+variable_host - the machine to install on (default is localhost). Must be defined in the hosts file
 download - 'yes' will download NICOS from the ESS staging area rather than cloning it from Gerrit
 ```
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -9,3 +9,5 @@
     nicos_instrument: "{{ instrument | default('demo') }}"
     nicos_username: "{{ username | default('nicos') }}"
     nicos_usergroup: "{{ usergroup | default('nicos') }}"
+    nicos_download: "{{ download | default('no') }}"
+    nicos_download_link: "http://project.esss.dk/owncloud/index.php/s/ClJ6YpCjH1IIiAr/download"

--- a/tasks/download-nicos.yml
+++ b/tasks/download-nicos.yml
@@ -6,7 +6,7 @@
     path: '{{nicos_src_dir}}'
     state: absent
 
-- name: make sure nicos is checked out
+- name: clone nicos
   become: yes
   git:
     repo: '{{ nicos_repo }}'
@@ -14,3 +14,13 @@
     version: '{{ nicos_version }}'
     refspec: '{{ nicos_refspec }}'
     force: yes
+  when: nicos_download == 'no'
+
+- name: download nicos
+  become: yes
+  unarchive:
+    src: "http://project.esss.dk/owncloud/index.php/s/ClJ6YpCjH1IIiAr/download"
+    dest: '/opt'
+    force: yes
+    remote_src: yes
+  when: nicos_download == 'yes'


### PR DESCRIPTION
Currently we install NICOS by cloning from the FRM2 Gerrit.
There may be occasions where we want to install a certain version of NICOS rather than clone the latest version, for example:

* we have a specific version we want to deploy on instruments
* we want to deploy a patch quickly as we don't have time to go through the Gerrit review process (1)
* we want to test stuff on a instrument before committing to Gerrit.
* ...

To test (on linux):
```
sudo ansible-playbook install-nicos.yml -e download=yes
```
This should install NICOS (/opt/nicos-core) and the ansible log should show `download nicos` rather than `clone nicos`. Also there is a file called `Hello.txt` in /opt/nicos-core which is only in the downloaded version.